### PR TITLE
🐛 GNOME 50 fixes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -182,7 +182,18 @@ export default class KandoIntegration extends Extension {
     let [x, y] = [0, 0];
 
     if (this._lastPointerDevice != null) {
-      if (utils.shellVersionIsAtLeast(49, 1)) {
+      if (utils.shellVersionIsAtLeast(50, "alpha")) {
+        // The sprite device property changed the name in 50.alpha :
+        // https://gitlab.gnome.org/GNOME/mutter/-/commit/8c0b25b911c0449ce8b3d58c810e4463c4f61916
+        global.stage.foreach_sprite((stage, sprite) => {
+          if (sprite.sprite_device == this._lastPointerDevice) {
+            const coords = sprite.get_coords();
+            [x, y] = [coords.x, coords.y];
+            return false; // Stop iteration.
+          }
+          return true;
+        });
+      } else if (utils.shellVersionIsAtLeast(49, 1)) {
         // This will hopefully work in the final 49.1 release:
         // https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/4668
         global.stage.foreach_sprite((stage, sprite) => {


### PR DESCRIPTION
The Clutter change renamed the sprite property from `device` to `sprite_device`. This causes `sprite.device` to be `null`, making the menu appear in the top-left corner.

This is a hotfix for the mutter change commit:
https://gitlab.gnome.org/GNOME/mutter/-/commit/8c0b25b911c0449ce8b3d58c810e4463c4f61916

Someone likely encountered this issue and opened the following report in Kando Menu:
https://github.com/kando-menu/kando/issues/1347